### PR TITLE
kwargs in jobflow get_entries

### DIFF
--- a/src/rxn_ca/workflow/jobs.py
+++ b/src/rxn_ca/workflow/jobs.py
@@ -20,7 +20,7 @@ def _build_reaction_library(
     ensure_phases: List[str] = None,
     metastability_cutoff: float = 0.1,
     exclude_theoretical: bool = True,
-    **kwargs_entry
+    **entry_kwargs
 ) -> tuple:
     """Build phase set and reaction library for a chemical system.
 
@@ -47,7 +47,7 @@ def _build_reaction_library(
         metastability_cutoff=metastability_cutoff,
         ensure_phases=ensure_phases or [],
         exclude_theoretical_phases=exclude_theoretical,
-        **kwargs_entry
+        **entry_kwargs
     )
     print(f"Got {len(entries)} entries for {chemical_system}")
     if ensure_phases:

--- a/src/rxn_ca/workflow/jobs.py
+++ b/src/rxn_ca/workflow/jobs.py
@@ -20,6 +20,7 @@ def _build_reaction_library(
     ensure_phases: List[str] = None,
     metastability_cutoff: float = 0.1,
     exclude_theoretical: bool = True,
+    **kwargs_entry
 ) -> tuple:
     """Build phase set and reaction library for a chemical system.
 
@@ -46,6 +47,7 @@ def _build_reaction_library(
         metastability_cutoff=metastability_cutoff,
         ensure_phases=ensure_phases or [],
         exclude_theoretical_phases=exclude_theoretical,
+        **kwargs_entry
     )
     print(f"Got {len(entries)} entries for {chemical_system}")
     if ensure_phases:

--- a/src/rxn_ca/workflow/jobs.py
+++ b/src/rxn_ca/workflow/jobs.py
@@ -84,6 +84,7 @@ def setup_reaction_library(
     metastability_cutoff: float = 0.1,
     exclude_theoretical: bool = True,
     save_to_file: bool = True,
+    **entry_kwargs
 ) -> ReactionLibraryData:
     """Set up phase set and reaction library for a chemical system.
 
@@ -111,6 +112,7 @@ def setup_reaction_library(
         ensure_phases,
         metastability_cutoff,
         exclude_theoretical,
+        **entry_kwargs
     )
 
     # Optionally save reaction library to file


### PR DESCRIPTION
added kwargs in _build_reaction_library so that you can pass things like thermo_type for get_entries 