### PR TITLE
test: fix optimization related tests

### DIFF
--- a/tests/optimization/test_optimizable_recipe.py
+++ b/tests/optimization/test_optimizable_recipe.py
@@ -32,31 +32,17 @@ class TestOptimizableRecipe:
                 hold_time=5,
             )
 
-    def test_ramp_rate_conversion(self):
-        """Ramp rate is converted to sweep_step_size."""
+    def test_ramp_step_time_backward_compat(self):
+        """Can still use ramp_step_time directly."""
         recipe = OptimizableRecipe(
             precursors={"BaO": 0.5},
             hold_temp=1000,
             hold_time=5,
-            ramp_rate=10.0,  # 10 K/step
+            ramp_step_time=5,
         )
 
-        # TEMP_STEP_SIZE = 50, so sweep_step_size = 50/10 = 5
-        assert recipe.ramp_rate == 10.0
-        assert recipe.sweep_step_size == 5
-
-    def test_sweep_step_size_backward_compat(self):
-        """Can still use sweep_step_size directly."""
-        recipe = OptimizableRecipe(
-            precursors={"BaO": 0.5},
-            hold_temp=1000,
-            hold_time=5,
-            sweep_step_size=5,
-        )
-
-        # ramp_rate = 50/5 = 10
-        assert recipe.sweep_step_size == 5
-        assert recipe.ramp_rate == 10.0
+        # ramp_step_time = 5
+        assert recipe.ramp_step_time == 5
 
     def test_to_recipe(self):
         """Can convert to ReactionRecipe."""
@@ -97,7 +83,7 @@ class TestOptimizableRecipe:
         params = {
             "hold_temp": 1000,
             "hold_time": 5,
-            "ramp_rate": 10.0,
+            "ramp_step_time": 5,
             "Ba_source_ratio": 0.5,
             "Ti_source_ratio": 0.5,
         }
@@ -115,7 +101,7 @@ class TestOptimizableRecipe:
 
         assert recipe.hold_temp == 1000
         assert recipe.hold_time == 5
-        assert recipe.ramp_rate == 10.0
+        assert recipe.ramp_step_time == 5
         assert recipe.precursors["BaO"] == 0.5
         assert recipe.precursors["TiO2"] == 0.5
         assert recipe.simulation_size == 8
@@ -133,6 +119,7 @@ class TestOptimizableRecipe:
 
         assert recipe.hold_temp == 1000
         assert recipe.hold_time == 5  # Default from params.get
+        assert recipe.ramp_step_time == 1  # Default from params.get
         assert recipe.precursors["BaO"] == 0.5  # Default ratio
 
     def test_repr(self):

--- a/tests/optimization/test_search_space.py
+++ b/tests/optimization/test_search_space.py
@@ -39,18 +39,18 @@ class TestSearchSpace:
         assert len(ss.parameters) == 1
         param = ss.parameters[0]
         assert param.name == "hold_time"
-        assert isinstance(param, ContinuousParameter)
+        assert isinstance(param, DiscreteParameter)
         assert param.low == 1
         assert param.high == 10
 
-    def test_add_ramp_rate_range(self):
-        """Ramp rate creates a continuous parameter."""
-        ss = SearchSpace().add_ramp_rate_range(5.0, 20.0)
+    def test_add_ramp_step_time_range(self):
+        """Ramp step time creates a continuous parameter."""
+        ss = SearchSpace().add_ramp_step_time_range(5, 20)
 
         assert len(ss.parameters) == 1
         param = ss.parameters[0]
-        assert param.name == "ramp_rate"
-        assert isinstance(param, ContinuousParameter)
+        assert param.name == "ramp_step_time"
+        assert isinstance(param, DiscreteParameter)
         assert param.low == 5.0
         assert param.high == 20.0
 
@@ -82,7 +82,7 @@ class TestSearchSpace:
             SearchSpace()
             .add_temperature_range(800, 1400, step=50)
             .add_hold_time_range(1, 15)
-            .add_ramp_rate_range(5.0, 20.0)
+            .add_ramp_step_time_range(5, 20)
             .add_precursor_slot("Ba_source", ["BaCO3", "BaO"])
             .add_precursor_ratio("Ba_source", 0.4, 0.6)
         )
@@ -91,7 +91,7 @@ class TestSearchSpace:
         param_names = [p.name for p in ss.parameters]
         assert "hold_temp" in param_names
         assert "hold_time" in param_names
-        assert "ramp_rate" in param_names
+        assert "ramp_step_time" in param_names
         assert "Ba_source" in param_names
         assert "Ba_source_ratio" in param_names
 


### PR DESCRIPTION
This pull request updates the test suite for the optimization module to reflect a shift from using "ramp_rate" to "ramp_step_time" as the primary parameter for ramping behavior. The changes ensure that tests and parameter handling are consistent with this new approach and improve backward compatibility.

**Test updates for ramp parameters:**

* Replaced all usage of `ramp_rate` with `ramp_step_time` in tests for `OptimizableRecipe`, including parameter creation, assertions, and backward compatibility checks. [[1]](diffhunk://#diff-ec83e1ea5c5fc8dfc4ff71d0524cac3528599abfa6c1c451db02cbbc9817a8e4L35-R45) [[2]](diffhunk://#diff-ec83e1ea5c5fc8dfc4ff71d0524cac3528599abfa6c1c451db02cbbc9817a8e4L100-R86) [[3]](diffhunk://#diff-ec83e1ea5c5fc8dfc4ff71d0524cac3528599abfa6c1c451db02cbbc9817a8e4L118-R104) [[4]](diffhunk://#diff-ec83e1ea5c5fc8dfc4ff71d0524cac3528599abfa6c1c451db02cbbc9817a8e4R122)

**Test updates for search space construction:**

* Updated search space tests to use `add_ramp_step_time_range` instead of `add_ramp_rate_range`, and changed assertions to expect `ramp_step_time` as a discrete parameter. [[1]](diffhunk://#diff-cf1877b15338cf7a184f3a9a786450c79317ece89635af2f64c5026f946e3dd4L42-R53) [[2]](diffhunk://#diff-cf1877b15338cf7a184f3a9a786450c79317ece89635af2f64c5026f946e3dd4L85-R85) [[3]](diffhunk://#diff-cf1877b15338cf7a184f3a9a786450c79317ece89635af2f64c5026f946e3dd4L94-R94)