### PR TITLE
bugfix: replace pkg_resources with importlib.resources for setuptools>=82 compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "setuptools",
     "numpy>=1.21.5",
     "matplotlib>=3.5.1",
     "tqdm>=4.63.0",

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,8 @@ setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Science/Research",
         "Intended Audience :: System Administrators",
@@ -82,6 +81,6 @@ setup(
         "Topic :: Other/Nonlisted Topic",
         "Topic :: Scientific/Engineering",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.11",
     tests_require=["pytest"],
 )

--- a/src/rxn_ca/utilities/transport.py
+++ b/src/rxn_ca/utilities/transport.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
 import numpy as np
-import pkg_resources
+from importlib.resources import files
 from monty.json import MontyDecoder
 from pymatgen.core.composition import Composition
 from pydantic import BaseModel, Field
@@ -323,7 +323,7 @@ class TransportDatabase:
             target_els = frozenset(chemsys.split("-"))
 
         transport_dir = Path(
-            pkg_resources.resource_filename("rxn_ca.phases", "transport_db")
+            str(files("rxn_ca.phases").joinpath("transport_db"))
         )
         db = cls()
         for json_path in sorted(transport_dir.glob("*.json")):


### PR DESCRIPTION
- Use importlib.resources.files in transport.py instead of pkg_resources
- Drop setuptools from runtime dependencies (only needed for pkg_resources)
- Align setup.py python_requires/classifiers with pyproject (>=3.11)