### PR TITLE
bugfix: load reaction library from path + aligned trajectories

### DIFF
--- a/src/rxn_ca/workflow/jobs.py
+++ b/src/rxn_ca/workflow/jobs.py
@@ -174,14 +174,30 @@ def run_simulation(
     from rxn_ca.utilities.parallel_sim import run_sim_parallel
     from rxn_ca.utilities.single_sim import run_single_sim
     from rxn_ca.analysis import BulkReactionAnalyzer
+    from rxn_ca.analysis.reaction_step_analyzer import AnalysisMode, AnalysisQuantity
+    from rxn_ca.analysis.visualization.phase_trace_calculator import (
+        PhaseTraceCalculator,
+        PhaseTraceConfig,
+    )
     from rxn_ca.reactions import ReactionLibrary
 
     recipe_dict = recipe.as_dict()
 
     # Set up phase set and reaction library
     if reaction_library_data is not None:
-        phase_set = SolidPhaseSet.from_dict(reaction_library_data.phase_set_dict)
-        reaction_lib = ReactionLibrary.from_dict(reaction_library_data.reaction_library_dict)
+        if reaction_library_data.reaction_library_path:
+            # The library was saved to a file (e.g. grid runs ship an empty-dict
+            # stub to keep the FireWorks spec small). Load the full library from
+            # disk; it carries the phase set as `reaction_lib.phases`.
+            reaction_lib = ReactionLibrary.from_file(reaction_library_data.reaction_library_path)
+            phase_set = reaction_lib.phases
+        elif reaction_library_data.reaction_library_dict:
+            phase_set = SolidPhaseSet.from_dict(reaction_library_data.phase_set_dict)
+            reaction_lib = ReactionLibrary.from_dict(reaction_library_data.reaction_library_dict)
+        else:
+            raise ValueError(
+                "reaction_library_data must include reaction_library_path or reaction_library_dict"
+            )
         chem_sys = reaction_library_data.chemical_system
         reaction_library_path = reaction_library_data.reaction_library_path
     else:
@@ -237,18 +253,38 @@ def run_simulation(
         analyzer.last_loaded_step_idx
     )
 
-    # Build trajectory: molar amounts at each step
-    molar_trajectory: Dict[str, List[float]] = {}
-    temp_trajectory: List[float] = []
+    # Build trajectory: molar amounts at each step.
+    #
+    # get_all_absolute_molar_amounts(step) returns ONLY the phases present at that
+    # step (absent phases are omitted). Appending per-step like that gives each
+    # phase a list whose length is "number of steps it happened to exist for",
+    # with NO record of WHICH steps -- so the per-phase trajectories lose their
+    # common step alignment and a consumed precursor becomes indistinguishable
+    # from a late-forming product. That produced nonsense mass fractions
+    # downstream (e.g. a single phase reading 1.0 at step 0).
+    #
+    # Use the same aligned builder the plotter uses (PhaseTraceCalculator): it
+    # walks every step and 0-fills phases absent at that step, keeping all phases
+    # on the common step axis. matter_phases=None keeps gas phases (e.g. CO2),
+    # matching the previous get_all_absolute_molar_amounts behaviour;
+    # minimum_required_prevalence=0.0 keeps every phase that ever appears.
     step_indices: List[int] = list(analyzer.loaded_step_idxs)
+    temp_trajectory: List[float] = [
+        recipe.heating_schedule.temp_at(step_idx) for step_idx in step_indices
+    ]
 
-    for step_idx in step_indices:
-        amounts = analyzer.get_all_absolute_molar_amounts(step_idx)
-        for phase, amount in amounts.items():
-            if phase not in molar_trajectory:
-                molar_trajectory[phase] = []
-            molar_trajectory[phase].append(amount)
-        temp_trajectory.append(analyzer.get_temperature_at(step_idx))
+    trace_calc = PhaseTraceCalculator(
+        analyzer.loaded_step_groups, analyzer.step_analyzer
+    )
+    molar_traces = trace_calc.get_general_traces(
+        PhaseTraceConfig(minimum_required_prevalence=0.0),
+        AnalysisQuantity.MOLES,
+        AnalysisMode.ABSOLUTE,
+        matter_phases=None,
+    )
+    molar_trajectory: Dict[str, List[float]] = {
+        t.name: [float(y) for y in t.ys] for t in molar_traces
+    }
 
     return SimulationOutput(
         final_molar_amounts=final_molar_amounts,


### PR DESCRIPTION
Port two hpc-jobs-trajectories fixes onto master's run_simulation so the grid-search workflow works end-to-end:

- Library loading: when reaction_library_data.reaction_library_path is set, load the full library from disk (grid runs ship empty stub dicts to keep the FireWorks spec small). Falls back to the existing from_dict path.

- Aligned trajectories: build molar_amounts_trajectory via PhaseTraceCalculator so every phase stays on the common step axis (0-filled where absent) instead of the ragged per-step append, which produced misaligned/nonsense mass fractions and was rejected by get_trajectories.py.